### PR TITLE
Feature: Lock Colors

### DIFF
--- a/src/components/MainPalette.vue
+++ b/src/components/MainPalette.vue
@@ -16,7 +16,7 @@ async function fetchPalette(hex: string, mode: string) {
   );
   const data = await response.json();
 
-  palette.value = data.colors ? formatColorData(data) : [];
+  return data;
 }
 
 function formatColorData(data: { colors: Array<IColor> }) {
@@ -56,7 +56,12 @@ function getRandomMode() {
 function getRandomizedPalette() {
   const hex = getRandomHex();
   const mode = getRandomMode();
-  fetchPalette(hex, mode);
+  fetchPalette(hex, mode).then((data) => {
+    if (data.colors) {
+      const colors = formatColorData(data);
+      updatePalette(colors);
+    }
+  });
 }
 
 function handleRandomizeClick(e: Event) {

--- a/src/components/MainPalette.vue
+++ b/src/components/MainPalette.vue
@@ -72,11 +72,15 @@ function toggleLock(id: string) {
 }
 
 function updatePalette(
-  data: Array<{ isLocked: boolean; hex: string; id: string }>
+  fetchedColors: Array<{ isLocked: boolean; hex: string; id: string }>
 ) {
-  palette.value.forEach((color, index) => {
-    if (!color.isLocked) palette.value[index] = data[index];
-  });
+  if (!palette.value.length) {
+    palette.value = fetchedColors;
+  } else {
+    palette.value.forEach((color, index) => {
+      if (!color.isLocked) palette.value[index] = fetchedColors[index];
+    });
+  }
 }
 
 onMounted(() => {

--- a/src/components/MainPalette.vue
+++ b/src/components/MainPalette.vue
@@ -64,6 +64,10 @@ function handleRandomizeClick(e: Event) {
   getRandomizedPalette();
 }
 
+function toggleLock(id: string) {
+  console.log(id);
+}
+
 onMounted(() => {
   getRandomizedPalette();
 });
@@ -76,6 +80,7 @@ onMounted(() => {
         v-for="(color, index) in palette"
         :color="color"
         :key="index + color.hex"
+        @toggle-lock="toggleLock"
       />
     </div>
     <button class="button" @click="handleRandomizeClick">Randomize</button>

--- a/src/components/MainPalette.vue
+++ b/src/components/MainPalette.vue
@@ -8,7 +8,7 @@ interface IColor {
   };
 }
 
-const palette = ref<Array<{ isLocked: boolean; hex: string }>>([]);
+const palette = ref<Array<{ isLocked: boolean; hex: string; id: string }>>([]);
 
 async function fetchPalette(hex: string, mode: string) {
   const response = await fetch(
@@ -24,6 +24,7 @@ function formatPalette(data: { colors: Array<IColor> }) {
     return {
       isLocked: false,
       hex: color.hex.clean,
+      id: Math.random().toString(36).substring(2, 8),
     };
   });
 }

--- a/src/components/MainPalette.vue
+++ b/src/components/MainPalette.vue
@@ -65,7 +65,10 @@ function handleRandomizeClick(e: Event) {
 }
 
 function toggleLock(id: string) {
-  console.log(id);
+  const index = palette.value.findIndex((color) => color.id === id);
+  const color = palette.value[index];
+
+  color.isLocked = !color.isLocked;
 }
 
 onMounted(() => {

--- a/src/components/MainPalette.vue
+++ b/src/components/MainPalette.vue
@@ -71,6 +71,14 @@ function toggleLock(id: string) {
   color.isLocked = !color.isLocked;
 }
 
+function updatePalette(
+  data: Array<{ isLocked: boolean; hex: string; id: string }>
+) {
+  palette.value.forEach((color, index) => {
+    if (!color.isLocked) palette.value[index] = data[index];
+  });
+}
+
 onMounted(() => {
   getRandomizedPalette();
 });

--- a/src/components/MainPalette.vue
+++ b/src/components/MainPalette.vue
@@ -16,10 +16,10 @@ async function fetchPalette(hex: string, mode: string) {
   );
   const data = await response.json();
 
-  palette.value = data.colors ? formatPalette(data) : [];
+  palette.value = data.colors ? formatColorData(data) : [];
 }
 
-function formatPalette(data: { colors: Array<IColor> }) {
+function formatColorData(data: { colors: Array<IColor> }) {
   return data.colors.map((color: IColor) => {
     return {
       isLocked: false,

--- a/src/components/MainSwatch.vue
+++ b/src/components/MainSwatch.vue
@@ -3,7 +3,7 @@ import IconLocked from "./icons/Locked.vue";
 import IconUnlocked from "./icons/Unlocked.vue";
 
 defineProps<{
-  color: { isLocked: boolean; hex: string };
+  color: { isLocked: boolean; hex: string; id: string };
 }>();
 </script>
 
@@ -15,8 +15,10 @@ defineProps<{
     ></div>
     <div class="color-details">
       <p>#{{ color.hex }}</p>
-      <IconLocked v-if="color.isLocked" />
-      <IconUnlocked v-else />
+      <button v-bind:id="color.id">
+        <IconLocked v-if="color.isLocked" />
+        <IconUnlocked v-else />
+      </button>
     </div>
   </div>
 </template>

--- a/src/components/MainSwatch.vue
+++ b/src/components/MainSwatch.vue
@@ -15,7 +15,7 @@ defineProps<{
     ></div>
     <div class="color-details">
       <p>#{{ color.hex }}</p>
-      <button v-bind:id="color.id">
+      <button class="lock-toggle" v-bind:id="color.id">
         <IconLocked v-if="color.isLocked" />
         <IconUnlocked v-else />
       </button>
@@ -44,6 +44,14 @@ defineProps<{
 svg {
   width: 2rem;
   height: 2rem;
+}
+
+.lock-toggle {
+  background-color: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
 }
 
 @media (max-width: 1024px) {

--- a/src/components/MainSwatch.vue
+++ b/src/components/MainSwatch.vue
@@ -5,6 +5,13 @@ import IconUnlocked from "./icons/Unlocked.vue";
 defineProps<{
   color: { isLocked: boolean; hex: string; id: string };
 }>();
+
+const emit = defineEmits(["toggleLock"]);
+
+const handleToggle = (event: Event) => {
+  const button = event.currentTarget as HTMLButtonElement;
+  emit("toggleLock", button?.id);
+};
 </script>
 
 <template>
@@ -15,7 +22,7 @@ defineProps<{
     ></div>
     <div class="color-details">
       <p>#{{ color.hex }}</p>
-      <button class="lock-toggle" v-bind:id="color.id">
+      <button class="lock-toggle" v-bind:id="color.id" @click="handleToggle">
         <IconLocked v-if="color.isLocked" />
         <IconUnlocked v-else />
       </button>

--- a/src/components/MainSwatch.vue
+++ b/src/components/MainSwatch.vue
@@ -22,7 +22,12 @@ const handleToggle = (event: Event) => {
     ></div>
     <div class="color-details">
       <p>#{{ color.hex }}</p>
-      <button class="lock-toggle" v-bind:id="color.id" @click="handleToggle">
+      <button
+        v-bind:aria-label="color.isLocked ? 'Unlock Color' : 'Lock Color'"
+        class="lock-toggle"
+        v-bind:id="color.id"
+        @click="handleToggle"
+      >
         <IconLocked v-if="color.isLocked" />
         <IconUnlocked v-else />
       </button>


### PR DESCRIPTION
## Category

- [ ] Bug Fix
- [x] New Feature
- [ ] Refactoring
- [ ] Testing
- [ ] Documentation

## Changes Implemented
- Add an `id` to colors in the palette
- Wrap the lock/unlock icons in a button with an aria label for accessibility
- Add an emit to the lock button
- Add an `updatePalette` function to handle state changes
- Refactor the `fetchPalette` function to remove state update
- When a color is locked, it is not replaced when the randomize button is clicked

<img height="450" alt="Main palette" src="https://user-images.githubusercontent.com/77205456/216837019-6e850368-9301-4731-8068-5555ddd0e48b.png">

## Notes/Next Steps
