### PR TITLE
Feature: Delete Palettes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -70,15 +70,18 @@ main {
 
 h2 {
   padding-bottom: 1rem;
+  white-space: nowrap;
 }
 
 ul {
+  list-style: none;
   padding: 0;
 }
 
 .saved-section {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   align-items: center;
   height: fit-content;
   padding: 1.5rem;

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,7 @@ function deletePalette(id: string) {
         <SavedPalette
           v-for="palette in savedPalettes"
           :palette="palette.colors"
+          :paletteId="palette.id"
           :key="'palette' + palette.id"
           @delete-palette="deletePalette"
         />

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,12 @@ function savePalette(
     colors: colors,
   });
 }
+
+function deletePalette(id: string) {
+  savedPalettes.value = savedPalettes.value.filter(
+    (palette) => palette.id !== id
+  );
+}
 </script>
 
 <template>
@@ -34,6 +40,7 @@ function savePalette(
           v-for="palette in savedPalettes"
           :palette="palette.colors"
           :key="'palette' + palette.id"
+          @delete-palette="deletePalette"
         />
       </ul>
     </section>

--- a/src/App.vue
+++ b/src/App.vue
@@ -50,8 +50,13 @@ function deletePalette(id: string) {
 
 <style scoped>
 header {
-  line-height: 4;
+  line-height: 2;
   text-align: center;
+}
+
+h1 {
+  border-bottom: 1px solid #262626;
+  margin: 2rem 0;
 }
 
 .title {
@@ -80,6 +85,7 @@ ul {
   text-align: center;
   background-color: #262626;
   border-radius: 0.5rem 0 0 0.5rem;
+  min-width: 15rem;
 }
 
 @media (max-width: 768px) {

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -9,7 +9,8 @@ const emit = defineEmits(["deletePalette"]);
 
 function handleDelete(event: Event) {
   const button = event.currentTarget as HTMLButtonElement;
-  console.log(button);
+  const id = button?.id.slice(3);
+  emit("deletePalette", id);
 }
 </script>
 

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -2,6 +2,7 @@
 import IconTrash from "./icons/Trash.vue";
 defineProps<{
   palette: Array<{ isLocked: boolean; hex: string; id: string }>;
+  paletteId: string;
 }>();
 
 const emit = defineEmits(["deletePalette"]);
@@ -20,7 +21,12 @@ function handleDelete(event: Event) {
       :key="'swatch' + color.id"
       :style="{ backgroundColor: '#' + color.hex }"
     ></div>
-    <button class="delete-button" aria-label="delete" @click="handleDelete">
+    <button
+      :id="'dl-' + paletteId"
+      class="delete-button"
+      aria-label="delete"
+      @click="handleDelete"
+    >
       <IconTrash />
     </button>
   </li>

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -3,6 +3,13 @@ import IconTrash from "./icons/Trash.vue";
 defineProps<{
   palette: Array<{ isLocked: boolean; hex: string; id: string }>;
 }>();
+
+const emit = defineEmits(["deletePalette"]);
+
+function handleDelete(event: Event) {
+  const button = event.currentTarget as HTMLButtonElement;
+  console.log(button);
+}
 </script>
 
 <template>
@@ -13,7 +20,7 @@ defineProps<{
       :key="'swatch' + color.id"
       :style="{ backgroundColor: '#' + color.hex }"
     ></div>
-    <button class="delete-button" aria-label="delete">
+    <button class="delete-button" aria-label="delete" @click="handleDelete">
       <IconTrash />
     </button>
   </li>


### PR DESCRIPTION
## Category

- [ ] Bug Fix
- [x] New Feature
- [ ] Refactoring
- [ ] Testing
- [ ] Documentation

## Changes Implemented
- Add functionality to Trash icon button
- Add a deletePalette function to handle data updates
- Pass palette ID to savedPalette as a prop
- Add palette ID to delete button
- Styling tweaks

![Delete palette demo gif](https://user-images.githubusercontent.com/77205456/219768233-214447c1-d955-4e5a-b6a6-f9ca3bf8181e.gif)

## Notes/Next Steps
- When saving a palette, the locked option of each color in the main palette is reset, this probably shouldn't happen