### PR TITLE
Feature: Save Palettes to localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ npm run lint
 ```
 
 ## Reflections
+
 I had some difficulty wrapping my mind around reactive state in Vue! Having mostly worked with React in the past, it felt very taboo to mutate my state variables directly. I would like to continue studying the options for reactivity, as I still don't have a firm grasp on when to reach for `reactive()` versus `ref()`.
 
 One feature that I really liked is the scoped styling option for components. This is a really handy feature that could be very useful for avoiding conflicts in larger applications. I enjoyed using CSS Modules during my apprenticeship for similar functionality, and it is nice to see a feature like this baked in!
 
 There is still a lot of room for continued exploration in this project, and many future additions to consider:
-- Save palettes in local storage to persist across refreshes
+
+- ~~Save palettes in local storage to persist across refreshes~~ Complete!
 - Allow users to name palettes
 - Allow users to click on a saved palette to bring it up in the main palette view
 - Allow users to choose the type of palette generated (monochromatic, triad, etc.)

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import MainPalette from "./components/MainPalette.vue";
 import SavedPalette from "./components/SavedPalette.vue";
 
@@ -17,17 +17,6 @@ watch(
   },
   { deep: true }
 );
-
-// const savedPalettes = computed({
-//   get() {
-//     console.log("get");
-//     return JSON.parse(localStorage.getItem("vpal-saved") ?? "[]");
-//   },
-//   set(palettes) {
-//     console.log("set");
-//     localStorage.setItem("vpal-saved", JSON.stringify(palettes));
-//   },
-// });
 
 function savePalette(
   colors: Array<{ isLocked: boolean; hex: string; id: string }>

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,14 @@ const savedPalettes = ref<
   }>
 >(JSON.parse(localStorage.getItem("vpal-saved") ?? "[]"));
 
+watch(
+  savedPalettes,
+  (newPalettes) => {
+    localStorage.setItem("vpal-saved", JSON.stringify(newPalettes));
+  },
+  { deep: true }
+);
+
 // const savedPalettes = computed({
 //   get() {
 //     console.log("get");

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,25 +1,25 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import MainPalette from "./components/MainPalette.vue";
 import SavedPalette from "./components/SavedPalette.vue";
 
-// const savedPalettes = ref<
-//   Array<{
-//     id: string;
-//     colors: Array<{ isLocked: boolean; hex: string; id: string }>;
-//   }>
-// >([]);
+const savedPalettes = ref<
+  Array<{
+    id: string;
+    colors: Array<{ isLocked: boolean; hex: string; id: string }>;
+  }>
+>(JSON.parse(localStorage.getItem("vpal-saved") ?? "[]"));
 
-const savedPalettes = computed({
-  get() {
-    console.log("get");
-    return JSON.parse(localStorage.getItem("vpal-saved") ?? "[]");
-  },
-  set(palettes) {
-    console.log("set");
-    localStorage.setItem("vpal-saved", JSON.stringify(palettes));
-  },
-});
+// const savedPalettes = computed({
+//   get() {
+//     console.log("get");
+//     return JSON.parse(localStorage.getItem("vpal-saved") ?? "[]");
+//   },
+//   set(palettes) {
+//     console.log("set");
+//     localStorage.setItem("vpal-saved", JSON.stringify(palettes));
+//   },
+// });
 
 function savePalette(
   colors: Array<{ isLocked: boolean; hex: string; id: string }>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,25 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import MainPalette from "./components/MainPalette.vue";
 import SavedPalette from "./components/SavedPalette.vue";
 
-const savedPalettes = ref<
-  Array<{
-    id: string;
-    colors: Array<{ isLocked: boolean; hex: string; id: string }>;
-  }>
->([]);
+// const savedPalettes = ref<
+//   Array<{
+//     id: string;
+//     colors: Array<{ isLocked: boolean; hex: string; id: string }>;
+//   }>
+// >([]);
+
+const savedPalettes = computed({
+  get() {
+    console.log("get");
+    return JSON.parse(localStorage.getItem("vpal-saved") ?? "[]");
+  },
+  set(palettes) {
+    console.log("set");
+    localStorage.setItem("vpal-saved", JSON.stringify(palettes));
+  },
+});
 
 function savePalette(
   colors: Array<{ isLocked: boolean; hex: string; id: string }>


### PR DESCRIPTION
## Category

- [ ] Bug Fix
- [x] New Feature
- [ ] Refactoring
- [ ] Testing
- [ ] Documentation

## Changes Implemented
- Add a `watcher` to the `savedPalettes` ref to update localStorage anytime the user adds or deletes a palette
- Updated README to reflect localStorage change 
