### PR TITLE
Refactor: Collapsible Saved Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/77205456/220200427-399e7092-d4a8-4e0b-afd5-cb8bd2950f7c.gif">
+  <img alt="Application demo gif" src="https://user-images.githubusercontent.com/77205456/224162787-6d84c304-4d8b-4864-a245-8ad9d6bb3662.gif">
 </p>
 
 ## Project Overview

--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ There is still a lot of room for continued exploration in this project, and many
 
 Palettes generated with <a target="\_blank" href="https://www.thecolorapi.com/">The Color API</a>
 
-<a target="_blank" href="https://icons8.com/icon/SZTl3l31z6gR/rgb-color-wheel">RGB Color Wheel</a>, <a target="_blank" href="https://icons8.com/icon/7DbfyX80LGwU/trash">Trash</a>, <a target="_blank" href="https://icons8.com/icon/3seXONfwoB83/padlock">Padlock</a>, and <a target="_blank" href="https://icons8.com/icon/0R7F3PxtxHVm/lock">Lock</a> icons by <a target="_blank" href="https://icons8.com">Icons8</a>
+<a target="_blank" href="https://icons8.com/icon/SZTl3l31z6gR/rgb-color-wheel">RGB Color Wheel</a>, <a target="_blank" href="https://icons8.com/icon/sfmAmtufhDys/folder">Folder</a>, <a target="_blank" href="https://icons8.com/icon/7DbfyX80LGwU/trash">Trash</a>, <a target="_blank" href="https://icons8.com/icon/3seXONfwoB83/padlock">Padlock</a>, and <a target="_blank" href="https://icons8.com/icon/0R7F3PxtxHVm/lock">Lock</a> icons by <a target="_blank" href="https://icons8.com">Icons8</a>
 
 Markdown badges by <a href="https://github.com/Ileriayo/markdown-badges">Ileriayo</a>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from "vue";
 import MainPalette from "./components/MainPalette.vue";
 import SavedPalette from "./components/SavedPalette.vue";
+import IconFolder from "./components/icons/Folder.vue";
 
 const savedPalettes = ref<
   Array<{
@@ -58,7 +59,7 @@ function deletePalette(id: string) {
         class="saved-section-toggle"
         @click="isSavedExpanded = !isSavedExpanded"
       >
-        Open
+        <IconFolder />
       </button>
       <h2>Saved Palettes</h2>
       <ul>
@@ -96,15 +97,18 @@ main {
 
 .saved-section-toggle {
   position: absolute;
-  left: -3vw;
+  left: -3.5vw;
   top: 6%;
-  text-orientation: upright;
-  writing-mode: vertical-lr;
   background-color: #262626;
   border: none;
   color: #fff;
-  padding: 5vw 1vw;
+  padding: 2vw 1vw;
   border-radius: 1vw 0 0 1vw;
+}
+
+svg {
+  width: 2rem;
+  height: 2rem;
 }
 
 h2 {

--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,7 @@ function deletePalette(id: string) {
           v-for="palette in savedPalettes"
           :palette="palette.colors"
           :paletteId="palette.id"
+          :tabbable="isSavedVisible"
           :key="'palette' + palette.id"
           @delete-palette="deletePalette"
         />

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,9 @@ function deletePalette(id: string) {
   <main>
     <MainPalette @save-palette="savePalette" />
     <section class="saved-section" :class="{ open: isSavedOpen }">
-      <button class="saved-section-toggle">Open</button>
+      <button class="saved-section-toggle" @click="isSavedOpen = !isSavedOpen">
+        Open
+      </button>
       <h2>Saved Palettes</h2>
       <ul>
         <SavedPalette

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@ const savedPalettes = ref<
 >(JSON.parse(localStorage.getItem("vpal-saved") ?? "[]"));
 const isSavedExpanded = ref(false);
 const isSavedVisible = computed(() => {
-  if (window.innerWidth > 1024 && !isSavedExpanded.value) {
+  if (window.innerWidth > 1023 && !isSavedExpanded.value) {
     return false;
   } else {
     return true;
@@ -58,6 +58,7 @@ function deletePalette(id: string) {
       <button
         class="saved-section-toggle"
         @click="isSavedExpanded = !isSavedExpanded"
+        :aria-label="isSavedVisible ? 'Close sidebar' : 'Open sidebar'"
       >
         <IconFolder />
       </button>

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,6 +34,16 @@ function savePalette(
     id: "palette-" + Math.random().toString(36).substring(2, 8),
     colors: colors,
   });
+  animateSave();
+}
+
+function animateSave() {
+  const button = document.querySelector(".saved-section-toggle");
+
+  if (button) {
+    button.classList.add("save-success");
+    setTimeout(() => button.classList.remove("save-success"), 600);
+  }
 }
 
 function deletePalette(id: string) {
@@ -111,7 +121,11 @@ main {
   padding: 2rem 1rem;
   position: absolute;
   right: 0;
-  transition: right 0.5s ease;
+  transition: right 0.5s ease, color 0.3s ease-in-out;
+}
+
+.save-success {
+  color: turquoise;
 }
 
 svg {

--- a/src/App.vue
+++ b/src/App.vue
@@ -64,6 +64,9 @@ function deletePalette(id: string) {
       </button>
       <h2>Saved Palettes</h2>
       <ul>
+        <li v-if="!savedPalettes.length">
+          You currently have no palettes saved.
+        </li>
         <SavedPalette
           v-for="palette in savedPalettes"
           :palette="palette.colors"
@@ -98,13 +101,13 @@ main {
 
 .saved-section-toggle {
   position: absolute;
-  left: -3.5vw;
+  left: -4rem;
   top: 6%;
   background-color: #262626;
   border: none;
   color: #fff;
-  padding: 2vw 1vw;
-  border-radius: 1vw 0 0 1vw;
+  padding: 2rem 1rem;
+  border-radius: 0.5rem 0 0 0.5rem;
 }
 
 svg {
@@ -113,6 +116,7 @@ svg {
 }
 
 h2 {
+  font-weight: revert;
   padding-bottom: 1rem;
   white-space: nowrap;
 }
@@ -161,7 +165,7 @@ ul {
     position: absolute;
     left: 0;
     margin-left: 100%;
-    transition: 0.5s ease;
+    transition: transform 0.5s ease;
   }
 
   .open {

--- a/src/App.vue
+++ b/src/App.vue
@@ -103,13 +103,14 @@ main {
 }
 
 .saved-section-toggle {
-  position: absolute;
-  right: 0;
   background-color: #262626;
   border: none;
-  color: #fff;
-  padding: 2rem 1rem;
   border-radius: 0.5rem 0 0 0.5rem;
+  color: #fff;
+  cursor: pointer;
+  padding: 2rem 1rem;
+  position: absolute;
+  right: 0;
   transition: right 0.5s ease;
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -50,18 +50,20 @@ function deletePalette(id: string) {
 
   <main>
     <MainPalette @save-palette="savePalette" />
+    <button
+      class="saved-section-toggle"
+      :class="{ 'toggle-open': isSavedExpanded }"
+      @click="isSavedExpanded = !isSavedExpanded"
+      :aria-label="isSavedVisible ? 'Close sidebar' : 'Open sidebar'"
+    >
+      <IconFolder />
+    </button>
     <section
       class="saved-section"
       :class="{ open: isSavedExpanded }"
       :aria-expanded="isSavedVisible"
+      :aria-hidden="!isSavedVisible"
     >
-      <button
-        class="saved-section-toggle"
-        @click="isSavedExpanded = !isSavedExpanded"
-        :aria-label="isSavedVisible ? 'Close sidebar' : 'Open sidebar'"
-      >
-        <IconFolder />
-      </button>
       <h2>Saved Palettes</h2>
       <ul>
         <li v-if="!savedPalettes.length">
@@ -101,13 +103,13 @@ main {
 
 .saved-section-toggle {
   position: absolute;
-  left: -4rem;
-  top: 6%;
+  right: 0;
   background-color: #262626;
   border: none;
   color: #fff;
   padding: 2rem 1rem;
   border-radius: 0.5rem 0 0 0.5rem;
+  transition: right 0.5s ease;
 }
 
 svg {
@@ -170,6 +172,10 @@ ul {
 
   .open {
     transform: translateX(-100%);
+  }
+
+  .toggle-open {
+    right: 14.5rem;
   }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -133,4 +133,17 @@ ul {
     display: none;
   }
 }
+
+@media (min-width: 1024px) {
+  .saved-section {
+    position: absolute;
+    left: 0;
+    margin-left: 100%;
+    transition: 0.5s ease;
+  }
+
+  .open {
+    transform: translateX(-100%);
+  }
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -42,6 +42,7 @@ function deletePalette(id: string) {
   <main>
     <MainPalette @save-palette="savePalette" />
     <section class="saved-section">
+      <button class="saved-section-toggle">Open</button>
       <h2>Saved Palettes</h2>
       <ul>
         <SavedPalette
@@ -74,6 +75,19 @@ h1 {
 main {
   display: flex;
   justify-content: space-between;
+}
+
+.saved-section-toggle {
+  position: absolute;
+  left: -3vw;
+  top: 6%;
+  text-orientation: upright;
+  writing-mode: vertical-lr;
+  background-color: #262626;
+  border: none;
+  color: #fff;
+  padding: 5vw 1vw;
+  border-radius: 1vw 0 0 1vw;
 }
 
 h2 {
@@ -111,6 +125,12 @@ ul {
     margin-top: 2rem;
     width: 20rem;
     height: 100%;
+  }
+}
+
+@media (max-width: 1024px) {
+  .saved-section-toggle {
+    display: none;
   }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ const savedPalettes = ref<
     colors: Array<{ isLocked: boolean; hex: string; id: string }>;
   }>
 >(JSON.parse(localStorage.getItem("vpal-saved") ?? "[]"));
+const isSavedOpen = ref(false);
 
 watch(
   savedPalettes,
@@ -41,7 +42,7 @@ function deletePalette(id: string) {
 
   <main>
     <MainPalette @save-palette="savePalette" />
-    <section class="saved-section">
+    <section class="saved-section" :class="{ open: isSavedOpen }">
       <button class="saved-section-toggle">Open</button>
       <h2>Saved Palettes</h2>
       <ul>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import MainPalette from "./components/MainPalette.vue";
 import SavedPalette from "./components/SavedPalette.vue";
 
@@ -9,7 +9,14 @@ const savedPalettes = ref<
     colors: Array<{ isLocked: boolean; hex: string; id: string }>;
   }>
 >(JSON.parse(localStorage.getItem("vpal-saved") ?? "[]"));
-const isSavedOpen = ref(false);
+const isSavedExpanded = ref(false);
+const isSavedVisible = computed(() => {
+  if (window.innerWidth > 1024 && !isSavedExpanded.value) {
+    return false;
+  } else {
+    return true;
+  }
+});
 
 watch(
   savedPalettes,
@@ -42,8 +49,15 @@ function deletePalette(id: string) {
 
   <main>
     <MainPalette @save-palette="savePalette" />
-    <section class="saved-section" :class="{ open: isSavedOpen }">
-      <button class="saved-section-toggle" @click="isSavedOpen = !isSavedOpen">
+    <section
+      class="saved-section"
+      :class="{ open: isSavedExpanded }"
+      :aria-expanded="isSavedVisible"
+    >
+      <button
+        class="saved-section-toggle"
+        @click="isSavedExpanded = !isSavedExpanded"
+      >
         Open
       </button>
       <h2>Saved Palettes</h2>

--- a/src/App.vue
+++ b/src/App.vue
@@ -179,4 +179,10 @@ ul {
     right: 14.5rem;
   }
 }
+
+@media (min-width: 1440px) {
+  .toggle-open {
+    right: calc(12vw + 3.5rem);
+  }
+}
 </style>

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -57,4 +57,5 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -3,6 +3,7 @@ import IconTrash from "./icons/Trash.vue";
 defineProps<{
   palette: Array<{ isLocked: boolean; hex: string; id: string }>;
   paletteId: string;
+  tabbable: boolean;
 }>();
 
 const emit = defineEmits(["deletePalette"]);
@@ -27,6 +28,7 @@ function handleDelete(event: Event) {
       class="delete-button"
       aria-label="delete"
       @click="handleDelete"
+      :tabindex="tabbable ? '0' : '-1'"
     >
       <IconTrash />
     </button>

--- a/src/components/icons/Folder.vue
+++ b/src/components/icons/Folder.vue
@@ -1,0 +1,19 @@
+<script lang="ts">
+export default {
+  name: "IconFolder",
+};
+</script>
+
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 72 72"
+    width="64px"
+    height="64px"
+  >
+    <path
+      fill="currentColor"
+      d="M10 33h52v16c0 4.962-4.037 9-9 9H19c-4.963 0-9-4.038-9-9V33zM62 27H10v-5c0-4.962 4.037-9 9-9h5.246c2.037 0 4.035.701 5.624 1.974l2.262 1.809C32.307 16.923 32.527 17 32.754 17H53c4.963 0 9 4.038 9 9V27z"
+    />
+  </svg>
+</template>


### PR DESCRIPTION
## Category
- [ ] Bug Fix
- [ ] New Feature
- [x] Refactoring
- [ ] Testing
- [ ] Documentation

![sidebardemo](https://user-images.githubusercontent.com/77205456/224162078-39f71c79-4cfa-4fc0-bdec-823cd9e5bdbf.gif)

## Changes Implemented
- Added a button/tab to the Saved Palettes section on desktop+ screens
- Made Saved section collapsed by default
- Added a new `Folder` icon component
- Added accessibility labels when Saved section is open/closed
- Prevented tab focus on `delete` buttons when Saved Palettes is closed
- Added an animation to the `Folder` icon when a new palette is saved
- Updated README

## Notes/Next Steps
