### PR TITLE
Feature: View Saved Palettes in Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ![Vite](https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white)
 ![Vercel](https://img.shields.io/badge/vercel-%23000000.svg?style=for-the-badge&logo=vercel&logoColor=white)
 
-I created this project to explore the [Vue.js](https://vuejs.org/) framework and [TypeScript](https://www.typescriptlang.org/). Users can create a palette of five colors using various generation modes, as well as lock in colors that they like between generations. Palettes can also be saved or deleted as desired.
+I created this project to explore the [Vue.js](https://vuejs.org/) framework and [TypeScript](https://www.typescriptlang.org/). Users can create a palette of five colors using various generation modes, as well as lock in colors that they like between generations. Palettes can also be saved for later viewing, or deleted if desired.
 
 ## Project Setup
 
@@ -49,11 +49,13 @@ I had some difficulty wrapping my mind around reactive state in Vue! Having most
 
 One feature that I really liked is the scoped styling option for components. This is a really handy feature that could be very useful for avoiding conflicts in larger applications. I enjoyed using CSS Modules during my apprenticeship for similar functionality, and it is nice to see a feature like this baked in!
 
+Vue provides several options for state management, but I decided to try out [Pinia](https://pinia.vuejs.org/) in this project. Setting up a store for the main palette was very straightforward, and I can see several opportunities to refactor other areas in the app. I struggled a bit using emits for actions like saving/deleting palettes, and adding a new Pinia store would make these actions much simpler!
+
 There is still a lot of room for continued exploration in this project, and many future additions to consider:
 
 - ~~Save palettes in local storage to persist across refreshes~~ Complete!
 - Allow users to name palettes
-- Allow users to click on a saved palette to bring it up in the main palette view
+- ~~Allow users to click on a saved palette to bring it up in the main palette view~~ Complete!
 - ~~Allow users to choose the type of palette generated (monochromatic, triad, etc.)~~ Complete!
 - Add functionality to share palettes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vue-palettes",
       "version": "0.0.0",
       "dependencies": {
+        "pinia": "^2.0.33",
         "vue": "^3.2.45"
       },
       "devDependencies": {
@@ -824,6 +825,11 @@
         "@vue/compiler-dom": "3.2.45",
         "@vue/shared": "3.2.45"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
+      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "7.0.0",
@@ -2934,6 +2940,56 @@
         "node": ">=4"
       }
     },
+    "node_modules/pinia": {
+      "version": "2.0.33",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.33.tgz",
+      "integrity": "sha512-HOj1yVV2itw6rNIrR2f7+MirGNxhORjrULL8GWgRwXsGSvEqIQ+SE0MYt6cwtpegzCda3i+rVTZM+AM7CG+kRg==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.5.0",
+        "vue-demi": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
+        "typescript": ">=4.4.4",
+        "vue": "^2.6.14 || ^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/vue-demi": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
+      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -3499,7 +3555,7 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4249,6 +4305,11 @@
         "@vue/compiler-dom": "3.2.45",
         "@vue/shared": "3.2.45"
       }
+    },
+    "@vue/devtools-api": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
+      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
     },
     "@vue/eslint-config-prettier": {
       "version": "7.0.0",
@@ -5809,6 +5870,23 @@
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "dev": true
     },
+    "pinia": {
+      "version": "2.0.33",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.33.tgz",
+      "integrity": "sha512-HOj1yVV2itw6rNIrR2f7+MirGNxhORjrULL8GWgRwXsGSvEqIQ+SE0MYt6cwtpegzCda3i+rVTZM+AM7CG+kRg==",
+      "requires": {
+        "@vue/devtools-api": "^6.5.0",
+        "vue-demi": "*"
+      },
+      "dependencies": {
+        "vue-demi": {
+          "version": "0.13.11",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
+          "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+          "requires": {}
+        }
+      }
+    },
     "postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -6185,7 +6263,7 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true
+      "devOptional": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },
   "dependencies": {
+    "pinia": "^2.0.33",
     "vue": "^3.2.45"
   },
   "devDependencies": {

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -2,7 +2,7 @@
 import IconTrash from "./icons/Trash.vue";
 import { usePaletteStore } from "@/stores/palette";
 
-defineProps<{
+const props = defineProps<{
   palette: Array<{ isLocked: boolean; hex: string; id: string }>;
   paletteId: string;
   tabbable: boolean;
@@ -17,11 +17,15 @@ function handleDelete(event: Event) {
   const id = button?.id.slice(3);
   emit("deletePalette", id);
 }
+
+function handleEnlarge() {
+  mainPalette.updatePalette(props.palette);
+}
 </script>
 
 <template>
   <li class="saved-wrapper">
-    <button class="swatches-wrapper">
+    <button class="swatches-wrapper" @click="handleEnlarge">
       <div
         v-for="color in palette"
         class="saved-swatch"

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -17,12 +17,14 @@ function handleDelete(event: Event) {
 
 <template>
   <li class="saved-wrapper">
-    <div
-      v-for="color in palette"
-      class="saved-swatch"
-      :key="'swatch' + color.id"
-      :style="{ backgroundColor: '#' + color.hex }"
-    ></div>
+    <button class="swatches-wrapper">
+      <div
+        v-for="color in palette"
+        class="saved-swatch"
+        :key="'swatch' + color.id"
+        :style="{ backgroundColor: '#' + color.hex }"
+      ></div>
+    </button>
     <button
       :id="'dl-' + paletteId"
       class="delete-button"
@@ -40,6 +42,14 @@ function handleDelete(event: Event) {
   display: flex;
   align-items: center;
   padding: 1vw 0;
+}
+
+.swatches-wrapper {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  padding: 0;
 }
 .saved-swatch {
   width: 2vw;

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -89,13 +89,13 @@ svg {
 
 @media (max-width: 1024px) {
   .saved-swatch {
-    width: 2.5vw;
-    height: 2.5vw;
+    width: 3vw;
+    height: 3vw;
   }
 
   svg {
-    width: 2.5vw;
-    height: 2.5vw;
+    width: 3vw;
+    height: 3vw;
   }
 }
 

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import IconTrash from "./icons/Trash.vue";
+import { usePaletteStore } from "@/stores/palette";
+
 defineProps<{
   palette: Array<{ isLocked: boolean; hex: string; id: string }>;
   paletteId: string;
@@ -7,6 +9,8 @@ defineProps<{
 }>();
 
 const emit = defineEmits(["deletePalette"]);
+
+const mainPalette = usePaletteStore();
 
 function handleDelete(event: Event) {
   const button = event.currentTarget as HTMLButtonElement;

--- a/src/components/SavedPalette.vue
+++ b/src/components/SavedPalette.vue
@@ -20,12 +20,21 @@ function handleDelete(event: Event) {
 
 function handleEnlarge() {
   mainPalette.updatePalette(props.palette);
+
+  const firstToggle = document.querySelector(
+    ".lock-toggle"
+  ) as HTMLButtonElement;
+  firstToggle.focus();
 }
 </script>
 
 <template>
   <li class="saved-wrapper">
-    <button class="swatches-wrapper" @click="handleEnlarge">
+    <button
+      aria-label="View in main"
+      class="swatches-wrapper"
+      @click="handleEnlarge"
+    >
       <div
         v-for="color in palette"
         class="saved-swatch"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import { createApp } from "vue";
+import { createPinia } from "pinia";
 import App from "./App.vue";
 
-import "./assets/main.css";
+const pinia = createPinia();
+const app = createApp(App);
 
-createApp(App).mount("#app");
+app.use(pinia);
+app.mount("#app");

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import { createApp } from "vue";
 import { createPinia } from "pinia";
+
 import App from "./App.vue";
+
+import "./assets/main.css";
 
 const pinia = createPinia();
 const app = createApp(App);

--- a/src/stores/palette.ts
+++ b/src/stores/palette.ts
@@ -1,0 +1,17 @@
+import { defineStore } from "pinia";
+
+interface IColor {
+  isLocked: boolean;
+  hex: string;
+  id: string;
+}
+
+interface IPaletteState {
+  colors: IColor[];
+}
+
+export const usePaletteStore = defineStore("palette", {
+  state: (): IPaletteState => ({
+    colors: [],
+  }),
+});

--- a/src/stores/palette.ts
+++ b/src/stores/palette.ts
@@ -14,4 +14,15 @@ export const usePaletteStore = defineStore("palette", {
   state: (): IPaletteState => ({
     colors: [],
   }),
+  actions: {
+    updatePalette(newColors: IColor[]) {
+      if (!this.colors.length) {
+        this.colors = newColors;
+      } else {
+        this.colors.forEach((color, index) => {
+          if (!color.isLocked) this.colors[index] = newColors[index];
+        });
+      }
+    },
+  },
 });


### PR DESCRIPTION
## Category
- [ ] Bug Fix
- [x] New Feature
- [x] Refactoring
- [ ] Testing
- [ ] Documentation

![expanddemo](https://user-images.githubusercontent.com/77205456/226463298-4b8554e5-467d-4b22-b7cd-4186af6b40ae.gif)

## Changes Implemented
- Installed Pinia
- Created Pinia store for main palette
- Updated `MainPalette` with new store
- Wrapped saved palette swatches in a button
- Added onClick function to display saved palette in main section
- Increased saved palette swatch size on tablet

## Notes/Next Steps
- Consider creating a Pinia store for saved palettes and refactoring to remove emits?
- Update `toggleLock` function to mesh with main palette store